### PR TITLE
TP Moteur de réservation & Calendrier — David Meguira

### DIFF
--- a/assets/controllers/datepicker_controller.js
+++ b/assets/controllers/datepicker_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from '@hotwired/stimulus';
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.min.css';
+
+export default class extends Controller {
+    static values = { unavailableCheckin: Array, unavailableCheckout: Array };
+
+    connect() {
+        const unavailable = this.unavailableCheckinValue;
+        const unavailableCheckout = this.unavailableCheckoutValue;
+        const unavailableSet = new Set(unavailable);
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        const checkinInput = this.element.querySelector('[data-datepicker-checkin]');
+        const checkoutInput = this.element.querySelector('[data-datepicker-checkout]');
+
+        const onDayCreate = (_dObj, _dStr, _fp, dayElem) => {
+            const iso = dayElem.dateObj.toISOString().slice(0, 10);
+            if (unavailableSet.has(iso)) {
+                dayElem.title = 'Date indisponible';
+            }
+        };
+
+        const addIcon = (fp) => {
+            const altInput = fp.altInput;
+            if (!altInput) return;
+            const wrapper = document.createElement('div');
+            wrapper.className = 'relative';
+            altInput.parentNode.insertBefore(wrapper, altInput);
+            wrapper.appendChild(altInput);
+            const icon = document.createElement('span');
+            icon.innerHTML = '<i class="fa-regular fa-calendar"></i>';
+            icon.className = 'pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm';
+            wrapper.appendChild(icon);
+        };
+
+        const checkinPicker = flatpickr(checkinInput, {
+            minDate: today,
+            disable: unavailable,
+            dateFormat: 'Y-m-d',
+            altInput: true,
+            altFormat: 'd/m/Y',
+            locale: { firstDayOfWeek: 1 },
+            onDayCreate,
+            onReady: (_d, _s, fp) => addIcon(fp),
+            onClose: (selectedDates) => {
+                if (selectedDates[0]) {
+                    const next = new Date(selectedDates[0]);
+                    next.setDate(next.getDate() + 1);
+                    checkoutPicker.set('minDate', next);
+                    checkoutPicker.open();
+                }
+            },
+        });
+
+        const checkoutPicker = flatpickr(checkoutInput, {
+            minDate: today,
+            disable: unavailableCheckout,
+            dateFormat: 'Y-m-d',
+            altInput: true,
+            altFormat: 'd/m/Y',
+            locale: { firstDayOfWeek: 1 },
+            onDayCreate,
+            onReady: (_d, _s, fp) => addIcon(fp),
+        });
+
+        void checkinPicker;
+    }
+}

--- a/assets/controllers/simpledatepicker_controller.js
+++ b/assets/controllers/simpledatepicker_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus';
+import flatpickr from 'flatpickr';
+import 'flatpickr/dist/flatpickr.min.css';
+
+export default class extends Controller {
+    connect() {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
+        const startInput = this.element.querySelector('[data-simpledatepicker-start]');
+        const endInput = this.element.querySelector('[data-simpledatepicker-end]');
+
+        if (!startInput || !endInput) return;
+
+        flatpickr(startInput, {
+            minDate: today,
+            dateFormat: 'Y-m-d',
+            locale: { firstDayOfWeek: 1 },
+            onClose: (selectedDates) => {
+                if (selectedDates[0]) {
+                    const next = new Date(selectedDates[0]);
+                    next.setDate(next.getDate() + 1);
+                    endPicker.set('minDate', next);
+                }
+            },
+        });
+
+        const endPicker = flatpickr(endInput, {
+            minDate: today,
+            dateFormat: 'Y-m-d',
+            locale: { firstDayOfWeek: 1 },
+        });
+    }
+}

--- a/conception.txt
+++ b/conception.txt
@@ -6,8 +6,9 @@ CONCEPTION TECHNIQUE — Moteur de réservation & calendrier (clone Airbnb)
   Reservation (checkinDate/checkoutDate en DATE, status pending/confirmed/completed/cancelled),
   PropertyAvailability (1 ligne/jour : isAvailable, priceOverride, minimumStay),
   ReservationStatusHistory (trace des transitions), PropertyICalSync (URL iCal).
-- Ajouts : Property.calendarToken (export iCal sécurisé) + entité BookingHold
-  (logement, voyageur, dates, expiresAt) pour le verrou de checkout (cf. point 2).
+- Ajouts : Property.calendarToken (export iCal sécurisé).
+  BookingHold (logement, voyageur, dates, expiresAt) est conçu mais non implémenté
+  (cf. point 2).
 - Archi : logique dans des Services (AvailabilityService, ReservationService,
   ICalExport/ImportService), requêtes de dates dans les Repositories, contrôleurs fins.
 
@@ -29,10 +30,9 @@ Du coup c'est seulement à la confirmation que je re-vérifie la dispo, et la co
 d'exclusion (pt 3) fait qu'une seule peut passer. Les Pending pas traités expirent à 24h
 (G.1), ça protège le voyageur qui attend une réponse.
 En mode instantané (instantBooking=true), la résa est confirmée auto si les dates sont
-libres. Sauf que le voyageur passe par une page de récap avant : pour pas qu'il finalise
-tout puis se fasse doubler, je pose un hold de 15 min (entité BookingHold + compte à
-rebours). Tant qu'un hold est actif, les autres voyageurs sont bloqués sur ces dates ;
-il saute à la confirmation, ou il expire tout seul s'il abandonne.
+libres. La contrainte d'exclusion garantit qu'une seule peut passer en cas de conflit.
+On pourrait améliorer l'UX avec un hold de 15 min (entité BookingHold envisagée) pour
+protéger le voyageur pendant la page de récap, mais ça n'est pas implémenté ici.
 En gros le cycle c'est pending -> confirmed -> completed, et pending/confirmed ->
 cancelled. Chaque changement est tracé dans ReservationStatusHistory.
 
@@ -88,8 +88,8 @@ PropertyAvailability le bloque.
 
 
 7. SCHÉMA DE FLUX
-- Réservation : récap (checkout) -> instantané : BookingHold 15 min -> confirmation
-  (re-vérif dispo) -> résa confirmed + suppression du hold ; sur demande : création pending.
+- Réservation : récap -> instantané : confirmed direct (contrainte d'exclusion protège) ;
+  sur demande : création pending.
   Flush en transaction (contrainte d'exclusion) -> log historique -> mails async ->
   redirect + flash.
 - Modération hôte : liste des Pending -> accepter (re-vérif -> confirmed) / refuser

--- a/conception.txt
+++ b/conception.txt
@@ -1,0 +1,107 @@
+CONCEPTION TECHNIQUE — Moteur de réservation & calendrier (clone Airbnb)
+
+
+0. MODÈLE DE DONNÉES
+- Existant réutilisé : Property (instantBooking, maxGuests, status, checkin/out en Time),
+  Reservation (checkinDate/checkoutDate en DATE, status pending/confirmed/completed/cancelled),
+  PropertyAvailability (1 ligne/jour : isAvailable, priceOverride, minimumStay),
+  ReservationStatusHistory (trace des transitions), PropertyICalSync (URL iCal).
+- Ajouts : Property.calendarToken (export iCal sécurisé) + entité BookingHold
+  (logement, voyageur, dates, expiresAt) pour le verrou de checkout (cf. point 2).
+- Archi : logique dans des Services (AvailabilityService, ReservationService,
+  ICalExport/ImportService), requêtes de dates dans les Repositories, contrôleurs fins.
+
+
+1. MODÉLISATION TEMPORELLE — le jour de check-out est-il réservable ?
+Oui car c'est un intervalle semi-ouvert [checkinDate, checkoutDate) en gros, le jour de
+départ est un jour de changement de client, pas une nuit occupée donc nb nuits =
+checkout - checkin
+Du coup, une nouvelle résa peut avoir checkin = checkout d'une autre résa
+
+
+2. GESTION DES ÉTATS — une demande Pending bloque-t-elle les dates ?
+Non, y'a que le Confirmed qui verrouille vraiment le calendrier (c'est ce que demande
+l'algo du sujet).
+En mode sur demande (instantBooking=false), plusieurs Pending peuvent coexister sur les
+mêmes dates et c'est l'hôte qui choisit.
+Si je bloquais dès le Pending ce serait du blocage abusif et l'hôte perdrait des clients.
+Du coup c'est seulement à la confirmation que je re-vérifie la dispo, et la contrainte
+d'exclusion (pt 3) fait qu'une seule peut passer. Les Pending pas traités expirent à 24h
+(G.1), ça protège le voyageur qui attend une réponse.
+En mode instantané (instantBooking=true), la résa est confirmée auto si les dates sont
+libres. Sauf que le voyageur passe par une page de récap avant : pour pas qu'il finalise
+tout puis se fasse doubler, je pose un hold de 15 min (entité BookingHold + compte à
+rebours). Tant qu'un hold est actif, les autres voyageurs sont bloqués sur ces dates ;
+il saute à la confirmation, ou il expire tout seul s'il abandonne.
+En gros le cycle c'est pending -> confirmed -> completed, et pending/confirmed ->
+cancelled. Chaque changement est tracé dans ReservationStatusHistory.
+
+
+3. CONCURRENCE — deux validations à la milliseconde près ?
+Le risque c'est une race condition : les deux lisent "libre" en même temps puis insèrent
+chacun leur résa. Une simple vérif en PHP suffit pas.
+Du coup je m'appuie sur Postgres avec une contrainte d'exclusion : EXCLUDE USING gist sur
+daterange(checkin_date, checkout_date, '[)'), seulement quand status=confirmed (et il faut
+l'extension btree_gist). Le '[)' reprend mon intervalle semi-ouvert de la Q1, donc le jour
+de rotation passe. C'est la base elle-même qui refuse deux confirmées qui se chevauchent.
+En gros le premier qui commit gagne, le deuxième viole la contrainte donc il se prend une
+exception + rollback, et je lui affiche "dates plus dispo". Jamais de double booking, et
+c'est garanti par la base, pas juste par mon code.
+
+
+4. PERFORMANCE — valider 20 nuits sans requêtes itératives ?
+Je fais 2 requêtes qui couvrent toute la plage d'un coup.
+Grace à test de chevauchement : existant.checkin < ma_checkout ET existant.checkout >
+ma_checkin — une seule requête, peu importe que je demande 2 ou 20 nuits.
+Donc une requête pour voir si une résa confirmée chevauche, et une autre pour voir si
+l'hôte a bloqué un jour dans la plage. La capacité (maxGuests) et le statut publié, je les
+check en mémoire, sans requête.
+Et je mets des index sur (property_id, status, checkin_date, checkout_date) et
+(property_id, available_date) pour que ça reste rapide.
+
+
+5. ASYNCHRONISME — email après flush ? si le broker tombe ?
+J'envoie le mail après le flush, jamais avant. Parce qu'avant le flush la résa a pas
+encore d'ID et elle est pas committée : si le flush plante après que j'ai envoyé le mail,
+j'ai prévenu le client d'une résa qui existe pas (et un mail ça se rollback pas).
+L'envoi est délégué au worker (messenger:consume), donc la réponse HTTP reste rapide et le
+mail part en tâche de fond.
+J'utilise le transport doctrine://default : les messages sont stockés en base, donc si le
+worker est coupé ils repartent à son redémarrage, rien n'est perdu.
+Et si on était sur RabbitMQ et qu'il tombe : Messenger encaisse ça avec des retries (avec
+backoff), et les messages qui échouent finissent dans un transport "failed" que je peux
+relancer à la main une fois le broker revenu (messenger:failed:retry) — rien n'est perdu,
+c'est juste différé. Pour des mails vraiment critiques on pourrait même garder doctrine://
+en fallback.
+
+
+6. STRUCTURE SQL DU CALENDRIER — jours ou périodes ?
+Je pars sur un hybride, chaque table pour ce qu'elle fait de mieux.
+Les réservations en périodes (checkin/checkout) : c'est compact, le test de chevauchement
+est simple et ça colle avec la contrainte d'exclusion.
+Les blocages et tarifs de l'hôte en jours (PropertyAvailability) : ça permet de régler le
+prix et le séjour min au jour près, et d'afficher un calendrier mensuel facilement.
+Tout en jours j'évite (365 lignes par an et par logement, et galère pour les périodes de
+prix), tout en périodes aussi.
+Au final un jour est dispo si aucune résa confirmée le couvre ET aucune ligne
+PropertyAvailability le bloque.
+
+
+7. SCHÉMA DE FLUX
+- Réservation : récap (checkout) -> instantané : BookingHold 15 min -> confirmation
+  (re-vérif dispo) -> résa confirmed + suppression du hold ; sur demande : création pending.
+  Flush en transaction (contrainte d'exclusion) -> log historique -> mails async ->
+  redirect + flash.
+- Modération hôte : liste des Pending -> accepter (re-vérif -> confirmed) / refuser
+  (motif -> cancelled) -> mail async.
+- Annulation : motif obligatoire -> cancelled -> dates libérées -> mails aux 2 parties.
+- Recherche (/search) : destination + dispo (checkin/checkout) + capacité (maxGuests ≥ guests).
+- Export iCal : /api/properties/{id}/calendar.ics?token= -> VCALENDAR des séjours confirmés,
+  403 sans token valide.
+- Import iCal (bonus) : commande app:ical:sync (cron) -> HttpClient lit l'URL -> blocages
+  dans PropertyAvailability ; gestion des conflits/suppressions ; maj lastSyncAt.
+
+
+8. BONUS ENVISAGÉS
+- G.1 expiration Pending 24h (worker) | G.5 timeline (ReservationStatusHistory) |
+  G.6 tarif dynamique front | G.8 notifs in-app (cloche, entité Notification).

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -23,4 +23,4 @@ framework:
 #            Symfony\Component\Notifier\Message\SmsMessage: async
 
             # Route your messages to the transports
-            # 'App\Message\YourMessage': async
+            App\Message\ReservationNotification: async

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -39,6 +39,7 @@ security:
         - { path: ^/api/docs, roles: PUBLIC_ACCESS }
         - { path: ^/api/contexts, roles: PUBLIC_ACCESS }
         - { path: ^/api/validation_errors, roles: PUBLIC_ACCESS }
+        - { path: '^/api/properties/[^/]+/calendar\.ics', roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: ROLE_USER }
         - { path: ^/(login|register|aide)$, roles: PUBLIC_ACCESS }
         - { path: ^/$, roles: PUBLIC_ACCESS }

--- a/importmap.php
+++ b/importmap.php
@@ -25,4 +25,11 @@ return [
     '@hotwired/turbo' => [
         'version' => '7.3.0',
     ],
+    'flatpickr' => [
+        'version' => '4.6.13',
+    ],
+    'flatpickr/dist/flatpickr.min.css' => [
+        'version' => '4.6.13',
+        'type' => 'css',
+    ],
 ];

--- a/migrations/Version20260611125001.php
+++ b/migrations/Version20260611125001.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260611125001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Empêche le chevauchement de deux réservations confirmées sur un même logement (contrainte EXCLUDE gist).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE EXTENSION IF NOT EXISTS btree_gist');
+        $this->addSql(<<<'SQL'
+            ALTER TABLE reservations ADD CONSTRAINT no_overlap_confirmed
+            EXCLUDE USING gist (
+                property_id WITH =,
+                daterange(checkin_date, checkout_date, '[)') WITH &&
+            ) WHERE (status = 'confirmed')
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE reservations DROP CONSTRAINT no_overlap_confirmed');
+    }
+}

--- a/migrations/Version20260611132410.php
+++ b/migrations/Version20260611132410.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260611132410 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE properties ADD calendar_token VARCHAR(64) DEFAULT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_87C331C73363A255 ON properties (calendar_token)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX UNIQ_87C331C73363A255');
+        $this->addSql('ALTER TABLE properties DROP calendar_token');
+    }
+}

--- a/src/Command/ICalSyncCommand.php
+++ b/src/Command/ICalSyncCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Repository\PropertyICalSyncRepository;
+use App\Service\ICalImportService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Input\InputInterface;
+
+#[AsCommand(name: 'app:ical:sync', description: 'Synchronise les calendriers iCal externes et bloque les nuitées correspondantes.')]
+final class ICalSyncCommand extends Command
+{
+    public function __construct(
+        private readonly PropertyICalSyncRepository $syncs,
+        private readonly ICalImportService $importer,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $syncs = $this->syncs->findAll();
+
+        if ($syncs === []) {
+            $io->info('Aucun calendrier iCal à synchroniser.');
+
+            return Command::SUCCESS;
+        }
+
+        $total = 0;
+        foreach ($syncs as $sync) {
+            try {
+                $blocked = $this->importer->sync($sync);
+                $total += $blocked;
+                $io->writeln(sprintf('%s : %d nuitée(s) bloquée(s)', $sync->getProviderName(), $blocked));
+            } catch (\Throwable $exception) {
+                $io->warning(sprintf('%s : échec (%s)', $sync->getProviderName(), $exception->getMessage()));
+            }
+        }
+
+        $io->success(sprintf('Synchronisation terminée : %d nuitée(s) bloquée(s).', $total));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/Api/PropertyCalendarController.php
+++ b/src/Controller/Api/PropertyCalendarController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Entity\Property;
+use App\Service\ICalExportService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class PropertyCalendarController extends AbstractController
+{
+    #[Route('/api/properties/{id}/calendar.ics', name: 'api_property_calendar', methods: ['GET'])]
+    public function export(Property $property, Request $request, ICalExportService $exporter): Response
+    {
+        $token = $property->getCalendarToken();
+        if ($token === null || !hash_equals($token, (string) $request->query->get('token'))) {
+            throw new AccessDeniedHttpException('Token de calendrier invalide.');
+        }
+
+        return new Response(
+            $exporter->export($property),
+            Response::HTTP_OK,
+            [
+                'Content-Type' => 'text/calendar; charset=utf-8',
+                'Content-Disposition' => sprintf('attachment; filename="property-%s.ics"', $property->getId()),
+            ],
+        );
+    }
+}

--- a/src/Controller/Front/BookingController.php
+++ b/src/Controller/Front/BookingController.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Controller\Front;
 
 use App\Entity\Property;
-use App\Entity\Reservation;
 use App\Entity\User;
+use App\Exception\UnavailableDatesException;
 use App\Form\BookingType;
 use App\Repository\PropertyRepository;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Service\ReservationService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +26,7 @@ final class BookingController extends AbstractController
         Request $request,
         Property $property,
         PropertyRepository $propertyRepository,
-        EntityManagerInterface $entityManager,
+        ReservationService $reservationService,
     ): Response {
         if ($property->getStatus() !== 'published') {
             throw $this->createNotFoundException('Ce logement n\'est pas disponible à la réservation.');
@@ -71,28 +71,16 @@ final class BookingController extends AbstractController
                 ]);
             }
 
-            $nights = (int) $checkin->diff($checkout)->days;
-            $nightlyRate = (float) $property->getPricePerNight();
-            $subtotal = $nightlyRate * $nights;
-            $cleaningFee = (float) ($property->getCleaningFee() ?? 0);
-            $serviceFee = round($subtotal * 0.12, 2);
-            $totalPrice = round($subtotal + $cleaningFee + $serviceFee, 2);
+            try {
+                $reservation = $reservationService->create($property, $user, $checkin, $checkout, $guestsCount);
+            } catch (UnavailableDatesException) {
+                $this->addFlash('error', 'Ces dates ne sont plus disponibles pour ce logement.');
 
-            $reservation = new Reservation();
-            $reservation->setProperty($property);
-            $reservation->setGuest($user);
-            $reservation->setCheckinDate($checkin);
-            $reservation->setCheckoutDate($checkout);
-            $reservation->setGuestsCount($guestsCount);
-            $reservation->setStatus($property->isInstantBooking() ? 'confirmed' : 'pending');
-            $reservation->setTotalPrice((string) $totalPrice);
-            $reservation->setCleaningFee($cleaningFee > 0 ? (string) $cleaningFee : null);
-            $reservation->setServiceFee((string) $serviceFee);
-            $reservation->setSecurityDeposit($property->getSecurityDeposit());
-            $reservation->setCurrency('EUR');
-
-            $entityManager->persist($reservation);
-            $entityManager->flush();
+                return $this->render('front/property/booking.html.twig', [
+                    'property' => $property,
+                    'form' => $form,
+                ]);
+            }
 
             $this->addFlash('success', 'Votre réservation a été enregistrée.');
 

--- a/src/Controller/Front/BookingController.php
+++ b/src/Controller/Front/BookingController.php
@@ -8,7 +8,9 @@ use App\Entity\Property;
 use App\Entity\User;
 use App\Exception\UnavailableDatesException;
 use App\Form\BookingType;
+use App\Repository\PropertyAvailabilityRepository;
 use App\Repository\PropertyRepository;
+use App\Repository\ReservationRepository;
 use App\Service\ReservationService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,6 +29,8 @@ final class BookingController extends AbstractController
         Property $property,
         PropertyRepository $propertyRepository,
         ReservationService $reservationService,
+        ReservationRepository $reservationRepository,
+        PropertyAvailabilityRepository $availabilityRepository,
     ): Response {
         if ($property->getStatus() !== 'published') {
             throw $this->createNotFoundException('Ce logement n\'est pas disponible à la réservation.');
@@ -56,19 +60,13 @@ final class BookingController extends AbstractController
             if ($checkin >= $checkout) {
                 $this->addFlash('error', 'La date de départ doit être postérieure à la date d\'arrivée.');
 
-                return $this->render('front/property/booking.html.twig', [
-                    'property' => $property,
-                    'form' => $form,
-                ]);
+                return $this->redirectToRoute('app_booking_checkout', ['id' => $property->getId()]);
             }
 
             if ($guestsCount > $property->getMaxGuests()) {
                 $this->addFlash('error', sprintf('Ce logement accepte au maximum %d voyageurs.', $property->getMaxGuests()));
 
-                return $this->render('front/property/booking.html.twig', [
-                    'property' => $property,
-                    'form' => $form,
-                ]);
+                return $this->redirectToRoute('app_booking_checkout', ['id' => $property->getId()]);
             }
 
             try {
@@ -76,10 +74,7 @@ final class BookingController extends AbstractController
             } catch (UnavailableDatesException) {
                 $this->addFlash('error', 'Ces dates ne sont plus disponibles pour ce logement.');
 
-                return $this->render('front/property/booking.html.twig', [
-                    'property' => $property,
-                    'form' => $form,
-                ]);
+                return $this->redirectToRoute('app_booking_checkout', ['id' => $property->getId()]);
             }
 
             $this->addFlash('success', 'Votre réservation a été enregistrée.');
@@ -87,9 +82,31 @@ final class BookingController extends AbstractController
             return $this->redirectToRoute('app_reservation_show', ['id' => $reservation->getId()]);
         }
 
+        $blockedDays = [];
+        foreach ($availabilityRepository->findBlockedForProperty($property) as $avail) {
+            $blockedDays[] = $avail->getAvailableDate()->format('Y-m-d');
+        }
+
+        $unavailableForCheckin = $blockedDays;
+        $unavailableForCheckout = $blockedDays;
+
+        foreach ($reservationRepository->findConfirmedForProperty($property) as $reservation) {
+            $d = $reservation->getCheckinDate();
+            while ($d < $reservation->getCheckoutDate()) {
+                $unavailableForCheckin[] = $d->format('Y-m-d');
+                // checkout on the checkin day of another reservation is valid [checkin, checkout)
+                if ($d > $reservation->getCheckinDate()) {
+                    $unavailableForCheckout[] = $d->format('Y-m-d');
+                }
+                $d = $d->modify('+1 day');
+            }
+        }
+
         return $this->render('front/property/booking.html.twig', [
             'property' => $property,
             'form' => $form,
+            'unavailableForCheckin' => array_values(array_unique($unavailableForCheckin)),
+            'unavailableForCheckout' => array_values(array_unique($unavailableForCheckout)),
         ]);
     }
 }

--- a/src/Controller/Front/HomeController.php
+++ b/src/Controller/Front/HomeController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Controller\Front;
 
 use App\Entity\Property;
+use App\Repository\PropertyAvailabilityRepository;
 use App\Repository\PropertyRepository;
+use App\Repository\ReservationRepository;
 use App\Repository\ReviewRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,15 +29,33 @@ class HomeController extends AbstractController
     #[Route('/logement/{id}', name: 'app_logement_detail')]
     #[IsGranted('ROLE_USER')]
     #[IsGranted(PropertyVoter::VIEW, subject: 'property')]
-    public function detail(Property $property, PropertyRepository $propertyRepository, ReviewRepository $reviewRepository): Response
-    {
+    public function detail(
+        Property $property,
+        PropertyRepository $propertyRepository,
+        ReviewRepository $reviewRepository,
+        ReservationRepository $reservationRepository,
+        PropertyAvailabilityRepository $availabilityRepository,
+    ): Response {
         $property = $propertyRepository->findOneForDetail($property) ?? $property;
         $allReviews = $reviewRepository->findByPropertyOrdered($property);
+
+        $unavailableDates = [];
+        foreach ($availabilityRepository->findBlockedForProperty($property) as $avail) {
+            $unavailableDates[$avail->getAvailableDate()->format('Y-m-d')] = true;
+        }
+        foreach ($reservationRepository->findConfirmedForProperty($property) as $reservation) {
+            $d = $reservation->getCheckinDate();
+            while ($d < $reservation->getCheckoutDate()) {
+                $unavailableDates[$d->format('Y-m-d')] = true;
+                $d = $d->modify('+1 day');
+            }
+        }
 
         return $this->render('front/property/show.html.twig', [
             'property' => $property,
             'reviews' => \array_slice($allReviews, 0, 5),
             'totalReviews' => \count($allReviews),
+            'unavailableDates' => $unavailableDates,
         ]);
     }
 

--- a/src/Controller/Front/HomeController.php
+++ b/src/Controller/Front/HomeController.php
@@ -57,13 +57,15 @@ class HomeController extends AbstractController
     {
         $checkin = $this->parseDate($request->query->get('checkin'));
         $checkout = $this->parseDate($request->query->get('checkout'));
+        $guests = $request->query->getInt('guests');
+        $destination = $request->query->get('destination');
 
         return $this->render('front/search/index.html.twig', [
-            'properties' => $propertyRepository->findForListing('published'),
+            'properties' => $propertyRepository->search($destination, $checkin, $checkout, $guests),
             'checkin' => $checkin,
             'checkout' => $checkout,
-            'guests' => $request->query->getInt('guests'),
-            'destination' => $request->query->get('destination'),
+            'guests' => $guests,
+            'destination' => $destination,
         ]);
     }
 

--- a/src/Controller/Front/HostController.php
+++ b/src/Controller/Front/HostController.php
@@ -82,13 +82,40 @@ final class HostController extends AbstractController
     }
 
     #[Route('/logements/{id}/calendrier', name: 'app_host_calendar', methods: ['GET'])]
-    public function calendar(Property $property, PropertyAvailabilityRepository $availabilityRepository): Response
-    {
+    public function calendar(
+        Property $property,
+        Request $request,
+        PropertyAvailabilityRepository $availabilityRepository,
+        ReservationRepository $reservationRepository,
+    ): Response {
         $this->assertHost($property);
+
+        $monthParam = $request->query->get('month');
+        $currentMonth = $monthParam
+            ? \DateTimeImmutable::createFromFormat('Y-m', $monthParam) ?: new \DateTimeImmutable('first day of this month')
+            : new \DateTimeImmutable('first day of this month');
+        $currentMonth = $currentMonth->modify('first day of this month');
+
+        $blockedDates = [];
+        foreach ($availabilityRepository->findBlockedForProperty($property) as $avail) {
+            $blockedDates[$avail->getAvailableDate()->format('Y-m-d')] = true;
+        }
+
+        $reservedRanges = [];
+        foreach ($reservationRepository->findConfirmedForProperty($property) as $reservation) {
+            $reservedRanges[] = [
+                'from' => $reservation->getCheckinDate()->format('Y-m-d'),
+                'to' => $reservation->getCheckoutDate()->format('Y-m-d'),
+                'guest' => $reservation->getGuest()?->getEmail() ?? '',
+            ];
+        }
 
         return $this->render('front/host/calendar.html.twig', [
             'property' => $property,
             'blocked' => $availabilityRepository->findBlockedForProperty($property),
+            'blockedDates' => $blockedDates,
+            'reservedRanges' => $reservedRanges,
+            'currentMonth' => $currentMonth,
         ]);
     }
 

--- a/src/Controller/Front/HostController.php
+++ b/src/Controller/Front/HostController.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Front;
+
+use App\Entity\Property;
+use App\Entity\Reservation;
+use App\Entity\User;
+use App\Exception\UnavailableDatesException;
+use App\Repository\PropertyAvailabilityRepository;
+use App\Repository\PropertyRepository;
+use App\Repository\ReservationRepository;
+use App\Service\HostAvailabilityService;
+use App\Service\ReservationService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/hote')]
+#[IsGranted('ROLE_USER')]
+final class HostController extends AbstractController
+{
+    #[Route('/demandes', name: 'app_host_requests', methods: ['GET'])]
+    public function requests(ReservationRepository $reservationRepository): Response
+    {
+        return $this->render('front/host/requests.html.twig', [
+            'reservations' => $reservationRepository->findPendingForHost($this->requireUser()),
+        ]);
+    }
+
+    #[Route('/demandes/{id}/accepter', name: 'app_host_request_accept', methods: ['POST'])]
+    public function accept(Reservation $reservation, Request $request, ReservationService $reservationService): Response
+    {
+        $this->assertHost($reservation->getProperty());
+        $this->assertCsrf('moderate_' . $reservation->getId(), $request);
+
+        try {
+            $reservationService->confirm($reservation, $this->requireUser());
+            $this->addFlash('success', 'Demande acceptée.');
+        } catch (UnavailableDatesException) {
+            $this->addFlash('error', 'Les dates ne sont plus disponibles, impossible de confirmer.');
+        } catch (\DomainException $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('app_host_requests');
+    }
+
+    #[Route('/demandes/{id}/refuser', name: 'app_host_request_refuse', methods: ['POST'])]
+    public function refuse(Reservation $reservation, Request $request, ReservationService $reservationService): Response
+    {
+        $this->assertHost($reservation->getProperty());
+        $this->assertCsrf('moderate_' . $reservation->getId(), $request);
+
+        $reason = trim((string) $request->request->get('reason'));
+        if ($reason === '') {
+            $this->addFlash('error', 'Le motif de refus est obligatoire.');
+
+            return $this->redirectToRoute('app_host_requests');
+        }
+
+        try {
+            $reservationService->refuse($reservation, $this->requireUser(), $reason);
+            $this->addFlash('success', 'Demande refusée.');
+        } catch (\DomainException $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('app_host_requests');
+    }
+
+    #[Route('/logements', name: 'app_host_properties', methods: ['GET'])]
+    public function properties(PropertyRepository $propertyRepository): Response
+    {
+        return $this->render('front/host/properties.html.twig', [
+            'properties' => $propertyRepository->findByHost($this->requireUser()),
+        ]);
+    }
+
+    #[Route('/logements/{id}/calendrier', name: 'app_host_calendar', methods: ['GET'])]
+    public function calendar(Property $property, PropertyAvailabilityRepository $availabilityRepository): Response
+    {
+        $this->assertHost($property);
+
+        return $this->render('front/host/calendar.html.twig', [
+            'property' => $property,
+            'blocked' => $availabilityRepository->findBlockedForProperty($property),
+        ]);
+    }
+
+    #[Route('/logements/{id}/bloquer', name: 'app_host_block', methods: ['POST'])]
+    public function block(Property $property, Request $request, HostAvailabilityService $hostAvailability): Response
+    {
+        $this->assertHost($property);
+        $this->assertCsrf('block_' . $property->getId(), $request);
+
+        $start = $this->parseDate($request->request->get('start'));
+        $end = $this->parseDate($request->request->get('end'));
+
+        if ($start === null || $end === null || $start >= $end) {
+            $this->addFlash('error', 'Période invalide.');
+
+            return $this->redirectToRoute('app_host_calendar', ['id' => $property->getId()]);
+        }
+
+        $blocked = $hostAvailability->blockPeriod($property, $start, $end);
+        $this->addFlash('success', sprintf('%d jour(s) bloqué(s).', $blocked));
+
+        return $this->redirectToRoute('app_host_calendar', ['id' => $property->getId()]);
+    }
+
+    #[Route('/logements/{id}/calendar-token', name: 'app_host_calendar_token', methods: ['POST'])]
+    public function calendarToken(Property $property, Request $request, EntityManagerInterface $em): Response
+    {
+        $this->assertHost($property);
+        $this->assertCsrf('token_' . $property->getId(), $request);
+
+        $property->regenerateCalendarToken();
+        $em->flush();
+        $this->addFlash('success', 'Lien de calendrier régénéré.');
+
+        return $this->redirectToRoute('app_host_calendar', ['id' => $property->getId()]);
+    }
+
+    private function requireUser(): User
+    {
+        $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $user;
+    }
+
+    private function assertHost(?Property $property): void
+    {
+        if ($property === null || (string) $property->getHost()?->getId() !== (string) $this->requireUser()->getId()) {
+            throw $this->createAccessDeniedException();
+        }
+    }
+
+    private function assertCsrf(string $id, Request $request): void
+    {
+        if (!$this->isCsrfTokenValid($id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+    }
+
+    private function parseDate(mixed $value): ?\DateTimeImmutable
+    {
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', $value);
+
+        return $date !== false ? $date : null;
+    }
+}

--- a/src/Controller/Front/ReservationController.php
+++ b/src/Controller/Front/ReservationController.php
@@ -7,7 +7,9 @@ namespace App\Controller\Front;
 use App\Entity\Reservation;
 use App\Entity\User;
 use App\Repository\ReservationRepository;
+use App\Service\ReservationService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use App\Security\Voter\ReservationVoter;
@@ -44,5 +46,33 @@ final class ReservationController extends AbstractController
         return $this->render('front/reservation/show.html.twig', [
             'reservation' => $reservation,
         ]);
+    }
+
+    #[Route('/{id}/annuler', name: 'app_reservation_cancel', methods: ['POST'])]
+    #[IsGranted(ReservationVoter::VIEW, subject: 'reservation')]
+    public function cancel(
+        Reservation $reservation,
+        Request $request,
+        ReservationService $reservationService,
+    ): Response {
+        if (!$this->isCsrfTokenValid('cancel_reservation_' . $reservation->getId(), (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $reason = trim((string) $request->request->get('reason'));
+        if ($reason === '') {
+            $this->addFlash('error', 'Le motif d\'annulation est obligatoire.');
+
+            return $this->redirectToRoute('app_reservation_show', ['id' => $reservation->getId()]);
+        }
+
+        try {
+            $reservationService->cancel($reservation, $this->getUser(), $reason);
+            $this->addFlash('success', 'Réservation annulée.');
+        } catch (\DomainException $exception) {
+            $this->addFlash('error', $exception->getMessage());
+        }
+
+        return $this->redirectToRoute('app_reservation_show', ['id' => $reservation->getId()]);
     }
 }

--- a/src/Entity/Property.php
+++ b/src/Entity/Property.php
@@ -131,6 +131,9 @@ class Property
     #[ORM\Column]
     private bool $instantBooking = false;
 
+    #[ORM\Column(length: 64, unique: true, nullable: true)]
+    private ?string $calendarToken = null;
+
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
     private ?\DateTimeImmutable $createdAt = null;
 
@@ -366,6 +369,25 @@ class Property
     public function setInstantBooking(bool $instantBooking): static
     {
         $this->instantBooking = $instantBooking;
+
+        return $this;
+    }
+
+    public function getCalendarToken(): ?string
+    {
+        return $this->calendarToken;
+    }
+
+    public function setCalendarToken(?string $calendarToken): static
+    {
+        $this->calendarToken = $calendarToken;
+
+        return $this;
+    }
+
+    public function regenerateCalendarToken(): static
+    {
+        $this->calendarToken = bin2hex(random_bytes(24));
 
         return $this;
     }

--- a/src/Exception/UnavailableDatesException.php
+++ b/src/Exception/UnavailableDatesException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+final class UnavailableDatesException extends \RuntimeException
+{
+    public function __construct(string $message = 'Ces dates ne sont plus disponibles.', ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Form/BookingType.php
+++ b/src/Form/BookingType.php
@@ -20,11 +20,13 @@ class BookingType extends AbstractType
             ->add('checkinDate', DateType::class, [
                 'label' => 'Arrivée',
                 'widget' => 'single_text',
+                'input' => 'datetime_immutable',
                 'constraints' => [new NotBlank(message: 'La date d\'arrivée est obligatoire.')],
             ])
             ->add('checkoutDate', DateType::class, [
                 'label' => 'Départ',
                 'widget' => 'single_text',
+                'input' => 'datetime_immutable',
                 'constraints' => [
                     new NotBlank(message: 'La date de départ est obligatoire.'),
                 ],

--- a/src/Message/ReservationNotification.php
+++ b/src/Message/ReservationNotification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Message;
+
+final class ReservationNotification
+{
+    public const string PENDING_REQUEST = 'pending_request';
+    public const string CONFIRMED = 'confirmed';
+    public const string REFUSED = 'refused';
+    public const string CANCELLED = 'cancelled';
+
+    public function __construct(
+        public readonly string $reservationId,
+        public readonly string $event,
+    ) {
+    }
+}

--- a/src/MessageHandler/ReservationNotificationHandler.php
+++ b/src/MessageHandler/ReservationNotificationHandler.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageHandler;
+
+use App\Entity\Reservation;
+use App\Message\ReservationNotification;
+use App\Repository\ReservationRepository;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Mime\Email;
+
+#[AsMessageHandler]
+final class ReservationNotificationHandler
+{
+    private const string FROM = 'no-reply@clone-airbnb.local';
+
+    public function __construct(
+        private readonly ReservationRepository $reservations,
+        private readonly MailerInterface $mailer,
+    ) {
+    }
+
+    public function __invoke(ReservationNotification $message): void
+    {
+        $reservation = $this->reservations->find($message->reservationId);
+        if ($reservation === null) {
+            return;
+        }
+
+        match ($message->event) {
+            ReservationNotification::PENDING_REQUEST => $this->sendPendingRequest($reservation),
+            ReservationNotification::CONFIRMED => $this->sendConfirmation($reservation),
+            ReservationNotification::REFUSED => $this->sendRefusal($reservation),
+            ReservationNotification::CANCELLED => $this->sendCancellation($reservation),
+            default => null,
+        };
+    }
+
+    private function sendPendingRequest(Reservation $reservation): void
+    {
+        $host = $reservation->getProperty()?->getHost()?->getEmail();
+        if ($host === null) {
+            return;
+        }
+
+        $this->send(
+            $host,
+            'Nouvelle demande de réservation',
+            sprintf(
+                "Vous avez une nouvelle demande pour %s.\n%s\nVoyageur : %s\nTotal : %s %s\n\nConnectez-vous à votre espace hôte pour accepter ou refuser.",
+                $this->propertyTitle($reservation),
+                $this->stayLine($reservation),
+                $reservation->getGuest()?->getEmail() ?? 'inconnu',
+                $reservation->getTotalPrice(),
+                $reservation->getCurrency(),
+            ),
+        );
+    }
+
+    private function sendConfirmation(Reservation $reservation): void
+    {
+        $stay = sprintf(
+            "%s\n%s\nTotal : %s %s",
+            $this->propertyTitle($reservation),
+            $this->stayLine($reservation),
+            $reservation->getTotalPrice(),
+            $reservation->getCurrency(),
+        );
+
+        $guest = $reservation->getGuest()?->getEmail();
+        if ($guest !== null) {
+            $this->send($guest, 'Votre réservation est confirmée', "Votre réservation est confirmée.\n\n" . $stay);
+        }
+
+        $host = $reservation->getProperty()?->getHost()?->getEmail();
+        if ($host !== null) {
+            $this->send($host, 'Une réservation a été confirmée', "Une réservation a été confirmée sur votre logement.\n\n" . $stay);
+        }
+    }
+
+    private function sendRefusal(Reservation $reservation): void
+    {
+        $guest = $reservation->getGuest()?->getEmail();
+        if ($guest === null) {
+            return;
+        }
+
+        $this->send(
+            $guest,
+            'Votre demande de réservation a été refusée',
+            sprintf(
+                "Votre demande pour %s a été refusée.\n%s\nMotif : %s",
+                $this->propertyTitle($reservation),
+                $this->stayLine($reservation),
+                $reservation->getCancellationReason() ?? 'non précisé',
+            ),
+        );
+    }
+
+    private function sendCancellation(Reservation $reservation): void
+    {
+        $body = sprintf(
+            "La réservation pour %s a été annulée.\n%s\nMotif : %s",
+            $this->propertyTitle($reservation),
+            $this->stayLine($reservation),
+            $reservation->getCancellationReason() ?? 'non précisé',
+        );
+
+        foreach ([
+            $reservation->getGuest()?->getEmail(),
+            $reservation->getProperty()?->getHost()?->getEmail(),
+        ] as $recipient) {
+            if ($recipient !== null) {
+                $this->send($recipient, 'Réservation annulée', $body);
+            }
+        }
+    }
+
+    private function send(string $to, string $subject, string $body): void
+    {
+        $this->mailer->send(
+            (new Email())
+                ->from(self::FROM)
+                ->to($to)
+                ->subject($subject)
+                ->text($body),
+        );
+    }
+
+    private function propertyTitle(Reservation $reservation): string
+    {
+        return $reservation->getProperty()?->getTitle() ?? 'votre logement';
+    }
+
+    private function stayLine(Reservation $reservation): string
+    {
+        return sprintf(
+            'Du %s au %s pour %d voyageur(s)',
+            $reservation->getCheckinDate()?->format('d/m/Y') ?? '',
+            $reservation->getCheckoutDate()?->format('d/m/Y') ?? '',
+            $reservation->getGuestsCount() ?? 0,
+        );
+    }
+}

--- a/src/Repository/PropertyAvailabilityRepository.php
+++ b/src/Repository/PropertyAvailabilityRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Property;
 use App\Entity\PropertyAvailability;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -16,5 +17,26 @@ class PropertyAvailabilityRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PropertyAvailability::class);
+    }
+
+    public function hasBlockedDay(
+        Property $property,
+        \DateTimeImmutable $checkinDate,
+        \DateTimeImmutable $checkoutDate,
+    ): bool {
+        $result = $this->createQueryBuilder('a')
+            ->select('a.id')
+            ->andWhere('a.property = :property')
+            ->andWhere('a.isAvailable = false')
+            ->andWhere('a.availableDate >= :checkin')
+            ->andWhere('a.availableDate < :checkout')
+            ->setParameter('property', $property)
+            ->setParameter('checkin', $checkinDate)
+            ->setParameter('checkout', $checkoutDate)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result !== null;
     }
 }

--- a/src/Repository/PropertyAvailabilityRepository.php
+++ b/src/Repository/PropertyAvailabilityRepository.php
@@ -19,6 +19,34 @@ class PropertyAvailabilityRepository extends ServiceEntityRepository
         parent::__construct($registry, PropertyAvailability::class);
     }
 
+    /**
+     * @return list<PropertyAvailability>
+     */
+    public function findBlockedForProperty(Property $property): array
+    {
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.property = :property')
+            ->andWhere('a.isAvailable = false')
+            ->andWhere('a.availableDate >= :today')
+            ->setParameter('property', $property)
+            ->setParameter('today', new \DateTimeImmutable('today'))
+            ->orderBy('a.availableDate', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findOneByPropertyAndDate(Property $property, \DateTimeImmutable $date): ?PropertyAvailability
+    {
+        return $this->createQueryBuilder('a')
+            ->andWhere('a.property = :property')
+            ->andWhere('a.availableDate = :date')
+            ->setParameter('property', $property)
+            ->setParameter('date', $date)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
     public function hasBlockedDay(
         Property $property,
         \DateTimeImmutable $checkinDate,

--- a/src/Repository/PropertyRepository.php
+++ b/src/Repository/PropertyRepository.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Property;
+use App\Entity\PropertyAvailability;
+use App\Entity\Reservation;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -96,6 +98,61 @@ class PropertyRepository extends ServiceEntityRepository
             ->setMaxResults(6)
             ->getQuery()
             ->getResult();
+    }
+
+    /**
+     * @return list<Property>
+     */
+    public function search(
+        ?string $destination,
+        ?\DateTimeImmutable $checkinDate,
+        ?\DateTimeImmutable $checkoutDate,
+        int $guests,
+    ): array {
+        $qb = $this->createQueryBuilder('p')
+            ->addSelect('m', 'a', 'r', 'host', 'hostProfile')
+            ->leftJoin('p.media', 'm')
+            ->leftJoin('p.address', 'a')
+            ->leftJoin('p.reviews', 'r')
+            ->leftJoin('p.host', 'host')
+            ->leftJoin('host.profile', 'hostProfile')
+            ->andWhere('p.status = :published')
+            ->setParameter('published', 'published')
+            ->orderBy('p.createdAt', 'DESC');
+
+        if ($destination !== null && $destination !== '') {
+            $qb->andWhere('LOWER(a.city) LIKE :destination OR LOWER(a.addressLine1) LIKE :destination')
+                ->setParameter('destination', '%' . mb_strtolower($destination) . '%');
+        }
+
+        if ($guests > 0) {
+            $qb->andWhere('p.maxGuests >= :guests')
+                ->setParameter('guests', $guests);
+        }
+
+        if ($checkinDate !== null && $checkoutDate !== null && $checkinDate < $checkoutDate) {
+            $overlap = $this->getEntityManager()->createQueryBuilder()
+                ->select('IDENTITY(res.property)')
+                ->from(Reservation::class, 'res')
+                ->where('res.status = :confirmed')
+                ->andWhere('res.checkinDate < :checkout')
+                ->andWhere('res.checkoutDate > :checkin');
+
+            $blocked = $this->getEntityManager()->createQueryBuilder()
+                ->select('IDENTITY(av.property)')
+                ->from(PropertyAvailability::class, 'av')
+                ->where('av.isAvailable = false')
+                ->andWhere('av.availableDate >= :checkin')
+                ->andWhere('av.availableDate < :checkout');
+
+            $qb->andWhere($qb->expr()->notIn('p.id', $overlap->getDQL()))
+                ->andWhere($qb->expr()->notIn('p.id', $blocked->getDQL()))
+                ->setParameter('confirmed', 'confirmed')
+                ->setParameter('checkin', $checkinDate)
+                ->setParameter('checkout', $checkoutDate);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 
     public function findOneForDetail(Property $property): ?Property

--- a/src/Repository/ReservationRepository.php
+++ b/src/Repository/ReservationRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Property;
 use App\Entity\Reservation;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -72,6 +73,31 @@ class ReservationRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
 
         return $result !== null ? (float) $result : 0.0;
+    }
+
+    public function hasConfirmedOverlap(
+        Property $property,
+        \DateTimeImmutable $checkinDate,
+        \DateTimeImmutable $checkoutDate,
+        ?Reservation $exclude = null,
+    ): bool {
+        $qb = $this->createQueryBuilder('r')
+            ->select('r.id')
+            ->andWhere('r.property = :property')
+            ->andWhere('r.status = :confirmed')
+            ->andWhere('r.checkinDate < :checkout')
+            ->andWhere('r.checkoutDate > :checkin')
+            ->setParameter('property', $property)
+            ->setParameter('confirmed', 'confirmed')
+            ->setParameter('checkin', $checkinDate)
+            ->setParameter('checkout', $checkoutDate)
+            ->setMaxResults(1);
+
+        if ($exclude !== null) {
+            $qb->andWhere('r != :exclude')->setParameter('exclude', $exclude);
+        }
+
+        return $qb->getQuery()->getOneOrNullResult() !== null;
     }
 
     /**

--- a/src/Repository/ReservationRepository.php
+++ b/src/Repository/ReservationRepository.php
@@ -75,6 +75,45 @@ class ReservationRepository extends ServiceEntityRepository
         return $result !== null ? (float) $result : 0.0;
     }
 
+    /**
+     * @return list<Reservation>
+     */
+    public function findPendingForHost(User $host): array
+    {
+        return $this->createQueryBuilder('r')
+            ->addSelect('p', 'm', 'a', 'g', 'gp')
+            ->leftJoin('r.property', 'p')
+            ->leftJoin('p.media', 'm')
+            ->leftJoin('p.address', 'a')
+            ->leftJoin('r.guest', 'g')
+            ->leftJoin('g.profile', 'gp')
+            ->andWhere('p.host = :host')
+            ->andWhere('r.status = :pending')
+            ->setParameter('host', $host)
+            ->setParameter('pending', 'pending')
+            ->orderBy('r.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return list<Reservation>
+     */
+    public function findConfirmedForProperty(Property $property): array
+    {
+        return $this->createQueryBuilder('r')
+            ->addSelect('g', 'gp')
+            ->leftJoin('r.guest', 'g')
+            ->leftJoin('g.profile', 'gp')
+            ->andWhere('r.property = :property')
+            ->andWhere('r.status = :confirmed')
+            ->setParameter('property', $property)
+            ->setParameter('confirmed', 'confirmed')
+            ->orderBy('r.checkinDate', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function hasConfirmedOverlap(
         Property $property,
         \DateTimeImmutable $checkinDate,

--- a/src/Service/AvailabilityService.php
+++ b/src/Service/AvailabilityService.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Property;
+use App\Entity\Reservation;
+use App\Repository\PropertyAvailabilityRepository;
+use App\Repository\ReservationRepository;
+
+final class AvailabilityService
+{
+    public function __construct(
+        private readonly ReservationRepository $reservations,
+        private readonly PropertyAvailabilityRepository $availabilities,
+    ) {
+    }
+
+    public function isAvailable(
+        Property $property,
+        \DateTimeImmutable $checkinDate,
+        \DateTimeImmutable $checkoutDate,
+        int $guests,
+        ?Reservation $exclude = null,
+    ): bool {
+        if ($checkinDate >= $checkoutDate) {
+            return false;
+        }
+
+        if ($property->getStatus() !== 'published') {
+            return false;
+        }
+
+        if ($guests < 1 || $guests > (int) $property->getMaxGuests()) {
+            return false;
+        }
+
+        if ($this->reservations->hasConfirmedOverlap($property, $checkinDate, $checkoutDate, $exclude)) {
+            return false;
+        }
+
+        return !$this->availabilities->hasBlockedDay($property, $checkinDate, $checkoutDate);
+    }
+}

--- a/src/Service/HostAvailabilityService.php
+++ b/src/Service/HostAvailabilityService.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Property;
+use App\Entity\PropertyAvailability;
+use App\Repository\PropertyAvailabilityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class HostAvailabilityService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly PropertyAvailabilityRepository $availabilities,
+    ) {
+    }
+
+    public function blockPeriod(Property $property, \DateTimeImmutable $start, \DateTimeImmutable $end): int
+    {
+        $blocked = 0;
+
+        for ($day = $start; $day < $end; $day = $day->modify('+1 day')) {
+            $availability = $this->availabilities->findOneByPropertyAndDate($property, $day);
+            if ($availability === null) {
+                $availability = (new PropertyAvailability())
+                    ->setProperty($property)
+                    ->setAvailableDate($day);
+                $this->em->persist($availability);
+            }
+            $availability->setIsAvailable(false);
+            ++$blocked;
+        }
+
+        $this->em->flush();
+
+        return $blocked;
+    }
+}

--- a/src/Service/ICalExportService.php
+++ b/src/Service/ICalExportService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Property;
+use App\Entity\Reservation;
+use App\Repository\ReservationRepository;
+
+final class ICalExportService
+{
+    public function __construct(
+        private readonly ReservationRepository $reservations,
+    ) {
+    }
+
+    public function export(Property $property): string
+    {
+        $lines = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Clone Airbnb//FR',
+        ];
+
+        foreach ($this->reservations->findConfirmedForProperty($property) as $reservation) {
+            array_push($lines, ...$this->event($property, $reservation));
+        }
+
+        $lines[] = 'END:VCALENDAR';
+
+        return implode("\r\n", $lines) . "\r\n";
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function event(Property $property, Reservation $reservation): array
+    {
+        $nights = (int) $reservation->getCheckinDate()->diff($reservation->getCheckoutDate())->days;
+
+        return [
+            'BEGIN:VEVENT',
+            sprintf('UID:res-%s@clone-airbnb.local', $reservation->getId()),
+            sprintf('SUMMARY:%s — %s', $this->escape($property->getTitle() ?? ''), $this->escape($reservation->getGuest()?->getEmail() ?? '')),
+            'DTSTART;VALUE=DATE:' . $reservation->getCheckinDate()->format('Ymd'),
+            'DTEND;VALUE=DATE:' . $reservation->getCheckoutDate()->format('Ymd'),
+            sprintf(
+                'DESCRIPTION:%s',
+                $this->escape(sprintf(
+                    'Séjour %d nuits — %s %s — %s',
+                    $nights,
+                    $reservation->getTotalPrice(),
+                    $reservation->getCurrency(),
+                    $reservation->getGuest()?->getEmail() ?? '',
+                )),
+            ),
+            'END:VEVENT',
+        ];
+    }
+
+    private function escape(string $value): string
+    {
+        return str_replace(["\\", ';', ',', "\n"], ['\\\\', '\\;', '\\,', '\\n'], $value);
+    }
+}

--- a/src/Service/ICalImportService.php
+++ b/src/Service/ICalImportService.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\PropertyAvailability;
+use App\Entity\PropertyICalSync;
+use App\Repository\PropertyAvailabilityRepository;
+use App\Repository\ReservationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class ICalImportService
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly EntityManagerInterface $em,
+        private readonly PropertyAvailabilityRepository $availabilities,
+        private readonly ReservationRepository $reservations,
+    ) {
+    }
+
+    public function sync(PropertyICalSync $sync): int
+    {
+        $property = $sync->getProperty();
+        $url = $sync->getICalUrl();
+        if ($property === null || $url === null) {
+            return 0;
+        }
+
+        $content = $this->httpClient->request('GET', $url)->getContent();
+        $blocked = 0;
+
+        foreach ($this->parsePeriods($content) as [$start, $end]) {
+            for ($day = $start; $day < $end; $day = $day->modify('+1 day')) {
+                if ($this->reservations->hasConfirmedOverlap($property, $day, $day->modify('+1 day'))) {
+                    continue;
+                }
+
+                if ($this->availabilities->findOneByPropertyAndDate($property, $day) !== null) {
+                    continue;
+                }
+
+                $availability = (new PropertyAvailability())
+                    ->setProperty($property)
+                    ->setAvailableDate($day)
+                    ->setIsAvailable(false);
+                $this->em->persist($availability);
+                ++$blocked;
+            }
+        }
+
+        $sync->setLastSyncAt(new \DateTimeImmutable());
+        $this->em->flush();
+
+        return $blocked;
+    }
+
+    /**
+     * @return list<array{0: \DateTimeImmutable, 1: \DateTimeImmutable}>
+     */
+    private function parsePeriods(string $ics): array
+    {
+        $periods = [];
+        $start = null;
+        $end = null;
+
+        foreach (preg_split('/\r\n|\r|\n/', $ics) ?: [] as $line) {
+            if (str_starts_with($line, 'DTSTART')) {
+                $start = $this->parseDate($line);
+            } elseif (str_starts_with($line, 'DTEND')) {
+                $end = $this->parseDate($line);
+            } elseif (str_starts_with($line, 'END:VEVENT')) {
+                if ($start !== null && $end !== null && $start < $end) {
+                    $periods[] = [$start, $end];
+                }
+                $start = $end = null;
+            }
+        }
+
+        return $periods;
+    }
+
+    private function parseDate(string $line): ?\DateTimeImmutable
+    {
+        $value = substr($line, (int) strpos($line, ':') + 1);
+        if (!preg_match('/(\d{8})/', $value, $matches)) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Ymd', $matches[1]);
+
+        return $date !== false ? $date : null;
+    }
+}

--- a/src/Service/ReservationService.php
+++ b/src/Service/ReservationService.php
@@ -9,8 +9,10 @@ use App\Entity\Reservation;
 use App\Entity\ReservationStatusHistory;
 use App\Entity\User;
 use App\Exception\UnavailableDatesException;
+use App\Message\ReservationNotification;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 final class ReservationService
 {
@@ -20,6 +22,7 @@ final class ReservationService
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly AvailabilityService $availability,
+        private readonly MessageBusInterface $bus,
     ) {
     }
 
@@ -59,7 +62,77 @@ final class ReservationService
             throw $exception;
         }
 
+        $event = $status === 'confirmed'
+            ? ReservationNotification::CONFIRMED
+            : ReservationNotification::PENDING_REQUEST;
+        $this->bus->dispatch(new ReservationNotification((string) $reservation->getId(), $event));
+
         return $reservation;
+    }
+
+    public function confirm(Reservation $reservation, User $actor): void
+    {
+        if ($reservation->getStatus() !== 'pending') {
+            throw new \DomainException('Seule une demande en attente peut être confirmée.');
+        }
+
+        if (!$this->availability->isAvailable(
+            $reservation->getProperty(),
+            $reservation->getCheckinDate(),
+            $reservation->getCheckoutDate(),
+            $reservation->getGuestsCount() ?? 1,
+            $reservation,
+        )) {
+            throw new UnavailableDatesException();
+        }
+
+        $this->transition($reservation, 'confirmed', $actor, null, ReservationNotification::CONFIRMED);
+    }
+
+    public function refuse(Reservation $reservation, User $actor, string $reason): void
+    {
+        if ($reservation->getStatus() !== 'pending') {
+            throw new \DomainException('Seule une demande en attente peut être refusée.');
+        }
+
+        $this->transition($reservation, 'cancelled', $actor, $reason, ReservationNotification::REFUSED);
+    }
+
+    public function cancel(Reservation $reservation, User $actor, string $reason): void
+    {
+        if (!\in_array($reservation->getStatus(), ['pending', 'confirmed'], true)) {
+            throw new \DomainException('Cette réservation ne peut plus être annulée.');
+        }
+
+        $this->transition($reservation, 'cancelled', $actor, $reason, ReservationNotification::CANCELLED);
+    }
+
+    private function transition(
+        Reservation $reservation,
+        string $newStatus,
+        User $actor,
+        ?string $reason,
+        string $event,
+    ): void {
+        $oldStatus = $reservation->getStatus();
+
+        try {
+            $this->em->wrapInTransaction(function () use ($reservation, $newStatus, $oldStatus, $actor, $reason): void {
+                $reservation->setStatus($newStatus);
+                if ($reason !== null) {
+                    $reservation->setCancellationReason($reason);
+                }
+                $this->logStatus($reservation, $oldStatus, $newStatus, $actor);
+            });
+        } catch (DriverException $exception) {
+            if ($exception->getSQLState() === self::EXCLUSION_VIOLATION_SQLSTATE) {
+                throw new UnavailableDatesException(previous: $exception);
+            }
+
+            throw $exception;
+        }
+
+        $this->bus->dispatch(new ReservationNotification((string) $reservation->getId(), $event));
     }
 
     private function applyPricing(Reservation $reservation, Property $property): void

--- a/src/Service/ReservationService.php
+++ b/src/Service/ReservationService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Property;
+use App\Entity\Reservation;
+use App\Entity\ReservationStatusHistory;
+use App\Entity\User;
+use App\Exception\UnavailableDatesException;
+use Doctrine\DBAL\Exception\DriverException;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ReservationService
+{
+    private const float SERVICE_FEE_RATE = 0.12;
+    private const string EXCLUSION_VIOLATION_SQLSTATE = '23P01';
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly AvailabilityService $availability,
+    ) {
+    }
+
+    public function create(
+        Property $property,
+        User $guest,
+        \DateTimeImmutable $checkinDate,
+        \DateTimeImmutable $checkoutDate,
+        int $guestsCount,
+    ): Reservation {
+        if (!$this->availability->isAvailable($property, $checkinDate, $checkoutDate, $guestsCount)) {
+            throw new UnavailableDatesException();
+        }
+
+        $status = $property->isInstantBooking() ? 'confirmed' : 'pending';
+
+        $reservation = new Reservation();
+        $reservation->setProperty($property);
+        $reservation->setGuest($guest);
+        $reservation->setCheckinDate($checkinDate);
+        $reservation->setCheckoutDate($checkoutDate);
+        $reservation->setGuestsCount($guestsCount);
+        $reservation->setStatus($status);
+        $reservation->setCurrency('EUR');
+        $this->applyPricing($reservation, $property);
+
+        try {
+            $this->em->wrapInTransaction(function () use ($reservation, $guest, $status): void {
+                $this->em->persist($reservation);
+                $this->logStatus($reservation, null, $status, $guest);
+            });
+        } catch (DriverException $exception) {
+            if ($exception->getSQLState() === self::EXCLUSION_VIOLATION_SQLSTATE) {
+                throw new UnavailableDatesException(previous: $exception);
+            }
+
+            throw $exception;
+        }
+
+        return $reservation;
+    }
+
+    private function applyPricing(Reservation $reservation, Property $property): void
+    {
+        $nights = (int) $reservation->getCheckinDate()->diff($reservation->getCheckoutDate())->days;
+        $subtotal = (float) $property->getPricePerNight() * $nights;
+        $cleaningFee = (float) ($property->getCleaningFee() ?? 0);
+        $serviceFee = round($subtotal * self::SERVICE_FEE_RATE, 2);
+        $total = round($subtotal + $cleaningFee + $serviceFee, 2);
+
+        $reservation->setCleaningFee($cleaningFee > 0 ? (string) $cleaningFee : null);
+        $reservation->setServiceFee((string) $serviceFee);
+        $reservation->setSecurityDeposit($property->getSecurityDeposit());
+        $reservation->setTotalPrice((string) $total);
+    }
+
+    private function logStatus(Reservation $reservation, ?string $oldStatus, string $newStatus, User $changedBy): void
+    {
+        $history = new ReservationStatusHistory();
+        $history->setReservation($reservation);
+        $history->setOldStatus($oldStatus);
+        $history->setNewStatus($newStatus);
+        $history->setChangedBy($changedBy);
+        $reservation->addStatusHistory($history);
+        $this->em->persist($history);
+    }
+}

--- a/templates/components/search_bar.html.twig
+++ b/templates/components/search_bar.html.twig
@@ -74,14 +74,14 @@
                         <label class="block text-xs font-bold text-gray-800 mb-2">Où</label>
                         <input type="text" name="destination" value="{{ destination }}" placeholder="Rechercher une destination" class="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-gray-900">
                     </div>
-                    <div class="grid grid-cols-2 gap-4">
+                    <div class="grid grid-cols-2 gap-4" data-controller="simpledatepicker">
                         <div>
                             <label class="block text-xs font-bold text-gray-800 mb-2">Arrivée</label>
-                            <input type="date" name="checkin" value="{{ checkin }}" class="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-gray-900">
+                            <input type="date" name="checkin" value="{{ checkin }}" data-simpledatepicker-start class="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-gray-900">
                         </div>
                         <div>
                             <label class="block text-xs font-bold text-gray-800 mb-2">Départ</label>
-                            <input type="date" name="checkout" value="{{ checkout }}" class="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-gray-900">
+                            <input type="date" name="checkout" value="{{ checkout }}" data-simpledatepicker-end class="w-full border border-gray-300 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-gray-900">
                         </div>
                     </div>
                     <div>

--- a/templates/front/host/calendar.html.twig
+++ b/templates/front/host/calendar.html.twig
@@ -1,25 +1,95 @@
 {% extends 'layout/app.html.twig' %}
 
 {% block content %}
-    <main class="flex-grow px-6 md:px-12 py-8 max-w-3xl mx-auto w-full">
+    <main class="flex-grow px-6 md:px-12 py-8 max-w-4xl mx-auto w-full">
         <a href="{{ path('app_host_properties') }}" class="text-sm text-gray-500">← Mes logements</a>
         <h1 class="text-2xl md:text-3xl font-semibold text-gray-900 mt-2 mb-8">Calendrier — {{ property.title }}</h1>
 
+        {% for label, messages in app.flashes %}
+            {% for message in messages %}
+                <div class="mb-4 px-4 py-3 rounded-xl text-sm {{ label == 'success' ? 'bg-emerald-50 text-emerald-800' : 'bg-red-50 text-red-800' }}">{{ message }}</div>
+            {% endfor %}
+        {% endfor %}
+
+        {# Calendrier mensuel #}
+        {% set prevMonth = currentMonth|date_modify('-1 month') %}
+        {% set nextMonth = currentMonth|date_modify('+1 month') %}
+        {% set daysInMonth = currentMonth|date_modify('last day of this month')|date('j')|number_format %}
+        {% set firstWeekday = currentMonth|date('N') %}
+
+        {# Calculer les jours réservés #}
+        {% set reservedDays = {} %}
+        {% for range in reservedRanges %}
+            {% set d = range.from|date_modify('0 days') %}
+            {% for i in 0..89 %}
+                {% set dayStr = d|date_modify('+' ~ i ~ ' days')|date('Y-m-d') %}
+                {% if dayStr >= range.from and dayStr < range.to %}
+                    {% set reservedDays = reservedDays|merge({(dayStr): range.guest}) %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+
+        <section class="border border-gray-200 rounded-xl p-5 bg-white mb-6">
+            <div class="flex items-center justify-between mb-4">
+                <a href="{{ path('app_host_calendar', { id: property.id, month: prevMonth|date('Y-m') }) }}"
+                   class="px-3 py-1 rounded-lg border border-gray-200 text-sm hover:bg-gray-50">←</a>
+                {% set monthNames = ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','Août','Septembre','Octobre','Novembre','Décembre'] %}
+                <h2 class="font-semibold text-gray-900">{{ monthNames[currentMonth|date('n') - 1] }} {{ currentMonth|date('Y') }}</h2>
+                <a href="{{ path('app_host_calendar', { id: property.id, month: nextMonth|date('Y-m') }) }}"
+                   class="px-3 py-1 rounded-lg border border-gray-200 text-sm hover:bg-gray-50">→</a>
+            </div>
+
+            <div class="grid grid-cols-7 gap-1 text-center mb-1">
+                {% for day in ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'] %}
+                    <div class="text-xs font-medium text-gray-400 py-1">{{ day }}</div>
+                {% endfor %}
+            </div>
+
+            <div class="grid grid-cols-7 gap-1 text-center">
+                {% if firstWeekday > 1 %}
+                    {% for blank in 1..(firstWeekday - 1) %}<div></div>{% endfor %}
+                {% endif %}
+
+                {% for day in 1..daysInMonth %}
+                    {% set dayStr = currentMonth|date_modify('+' ~ (day - 1) ~ ' days')|date('Y-m-d') %}
+                    {% set isBlocked = blockedDates[dayStr] is defined %}
+                    {% set isReserved = reservedDays[dayStr] is defined %}
+                    {% set isToday = dayStr == 'now'|date('Y-m-d') %}
+
+                    <div class="relative rounded-lg py-2 text-sm
+                        {% if isReserved %} bg-brand text-white font-medium
+                        {% elseif isBlocked %} bg-gray-200 text-gray-500 line-through
+                        {% elseif isToday %} border-2 border-brand text-brand font-bold
+                        {% else %} text-gray-700 hover:bg-gray-50
+                        {% endif %}"
+                        {% if isReserved %}title="Réservé par {{ reservedDays[dayStr] }}"{% endif %}>
+                        {{ day }}
+                    </div>
+                {% endfor %}
+            </div>
+
+            <div class="flex gap-4 mt-4 text-xs text-gray-500">
+                <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-brand inline-block"></span> Réservé</span>
+                <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-gray-200 inline-block"></span> Bloqué</span>
+                <span class="flex items-center gap-1"><span class="w-3 h-3 rounded border-2 border-brand inline-block"></span> Aujourd'hui</span>
+            </div>
+        </section>
+
         <section class="border border-gray-200 rounded-xl p-5 bg-white mb-6">
             <h2 class="font-semibold text-gray-900 mb-3">Bloquer une période</h2>
-            <form method="post" action="{{ path('app_host_block', { id: property.id }) }}" class="flex flex-wrap items-end gap-3">
+            <form method="post" action="{{ path('app_host_block', { id: property.id }) }}" class="flex flex-wrap items-end gap-3" data-controller="simpledatepicker">
                 <input type="hidden" name="_token" value="{{ csrf_token('block_' ~ property.id) }}">
                 <label class="text-sm text-gray-600">Du
-                    <input type="date" name="start" required class="block mt-1 px-3 py-2 border border-gray-300 rounded-lg">
+                    <input type="date" name="start" required data-simpledatepicker-start class="block mt-1 px-3 py-2 border border-gray-300 rounded-lg">
                 </label>
                 <label class="text-sm text-gray-600">Au
-                    <input type="date" name="end" required class="block mt-1 px-3 py-2 border border-gray-300 rounded-lg">
+                    <input type="date" name="end" required data-simpledatepicker-end class="block mt-1 px-3 py-2 border border-gray-300 rounded-lg">
                 </label>
                 <button class="px-4 py-2 rounded-lg bg-gray-900 text-white text-sm font-medium">Bloquer</button>
             </form>
         </section>
 
-        <section class="border border-gray-200 rounded-xl p-5 bg-white mb-6">
+        <section class="border border-gray-200 rounded-xl p-5 bg-white">
             <h2 class="font-semibold text-gray-900 mb-3">Synchronisation iCal</h2>
             {% if property.calendarToken %}
                 <p class="text-sm text-gray-600 break-all mb-3">
@@ -34,21 +104,6 @@
                     {{ property.calendarToken ? 'Régénérer le lien' : 'Générer le lien' }}
                 </button>
             </form>
-        </section>
-
-        <section class="border border-gray-200 rounded-xl p-5 bg-white">
-            <h2 class="font-semibold text-gray-900 mb-3">Jours bloqués à venir</h2>
-            {% if blocked|length > 0 %}
-                <div class="flex flex-wrap gap-2">
-                    {% for availability in blocked %}
-                        <span class="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
-                            {{ availability.availableDate|date('d/m/Y') }}
-                        </span>
-                    {% endfor %}
-                </div>
-            {% else %}
-                <p class="text-gray-500 text-sm">Aucun jour bloqué.</p>
-            {% endif %}
         </section>
     </main>
 {% endblock %}

--- a/templates/front/host/calendar.html.twig
+++ b/templates/front/host/calendar.html.twig
@@ -1,0 +1,54 @@
+{% extends 'layout/app.html.twig' %}
+
+{% block content %}
+    <main class="flex-grow px-6 md:px-12 py-8 max-w-3xl mx-auto w-full">
+        <a href="{{ path('app_host_properties') }}" class="text-sm text-gray-500">← Mes logements</a>
+        <h1 class="text-2xl md:text-3xl font-semibold text-gray-900 mt-2 mb-8">Calendrier — {{ property.title }}</h1>
+
+        <section class="border border-gray-200 rounded-xl p-5 bg-white mb-6">
+            <h2 class="font-semibold text-gray-900 mb-3">Bloquer une période</h2>
+            <form method="post" action="{{ path('app_host_block', { id: property.id }) }}" class="flex flex-wrap items-end gap-3">
+                <input type="hidden" name="_token" value="{{ csrf_token('block_' ~ property.id) }}">
+                <label class="text-sm text-gray-600">Du
+                    <input type="date" name="start" required class="block mt-1 px-3 py-2 border border-gray-300 rounded-lg">
+                </label>
+                <label class="text-sm text-gray-600">Au
+                    <input type="date" name="end" required class="block mt-1 px-3 py-2 border border-gray-300 rounded-lg">
+                </label>
+                <button class="px-4 py-2 rounded-lg bg-gray-900 text-white text-sm font-medium">Bloquer</button>
+            </form>
+        </section>
+
+        <section class="border border-gray-200 rounded-xl p-5 bg-white mb-6">
+            <h2 class="font-semibold text-gray-900 mb-3">Synchronisation iCal</h2>
+            {% if property.calendarToken %}
+                <p class="text-sm text-gray-600 break-all mb-3">
+                    {{ url('api_property_calendar', { id: property.id }) }}?token={{ property.calendarToken }}
+                </p>
+            {% else %}
+                <p class="text-sm text-gray-500 mb-3">Aucun lien généré.</p>
+            {% endif %}
+            <form method="post" action="{{ path('app_host_calendar_token', { id: property.id }) }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('token_' ~ property.id) }}">
+                <button class="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium">
+                    {{ property.calendarToken ? 'Régénérer le lien' : 'Générer le lien' }}
+                </button>
+            </form>
+        </section>
+
+        <section class="border border-gray-200 rounded-xl p-5 bg-white">
+            <h2 class="font-semibold text-gray-900 mb-3">Jours bloqués à venir</h2>
+            {% if blocked|length > 0 %}
+                <div class="flex flex-wrap gap-2">
+                    {% for availability in blocked %}
+                        <span class="px-3 py-1 rounded-full bg-gray-100 text-gray-700 text-sm">
+                            {{ availability.availableDate|date('d/m/Y') }}
+                        </span>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <p class="text-gray-500 text-sm">Aucun jour bloqué.</p>
+            {% endif %}
+        </section>
+    </main>
+{% endblock %}

--- a/templates/front/host/properties.html.twig
+++ b/templates/front/host/properties.html.twig
@@ -1,0 +1,25 @@
+{% extends 'layout/app.html.twig' %}
+
+{% block content %}
+    <main class="flex-grow px-6 md:px-12 py-8 max-w-5xl mx-auto w-full">
+        <h1 class="text-2xl md:text-3xl font-semibold text-gray-900 mb-1">Mes logements</h1>
+        <p class="text-gray-500 mb-8">Gérez le calendrier et les disponibilités de vos logements.</p>
+
+        {% if properties|length > 0 %}
+            <div class="space-y-3">
+                {% for property in properties %}
+                    <a href="{{ path('app_host_calendar', { id: property.id }) }}"
+                       class="flex items-center justify-between border border-gray-200 rounded-xl p-4 bg-white hover:bg-gray-50">
+                        <div>
+                            <p class="font-semibold text-gray-900">{{ property.title }}</p>
+                            <p class="text-sm text-gray-500">{{ property.status }} · {{ property.maxGuests }} voyageurs max</p>
+                        </div>
+                        <span class="text-sm text-gray-500">Calendrier →</span>
+                    </a>
+                {% endfor %}
+            </div>
+        {% else %}
+            <p class="text-gray-500">Vous n'avez aucun logement.</p>
+        {% endif %}
+    </main>
+{% endblock %}

--- a/templates/front/host/requests.html.twig
+++ b/templates/front/host/requests.html.twig
@@ -1,0 +1,43 @@
+{% extends 'layout/app.html.twig' %}
+
+{% block content %}
+    <main class="flex-grow px-6 md:px-12 py-8 max-w-5xl mx-auto w-full">
+        <h1 class="text-2xl md:text-3xl font-semibold text-gray-900 mb-1">Demandes de réservation</h1>
+        <p class="text-gray-500 mb-8">Les demandes en attente sur vos logements.</p>
+
+        {% if reservations|length > 0 %}
+            <div class="space-y-4">
+                {% for reservation in reservations %}
+                    <div class="border border-gray-200 rounded-xl p-5 bg-white">
+                        <div class="flex flex-wrap justify-between gap-4">
+                            <div>
+                                <p class="font-semibold text-gray-900">{{ reservation.property.title }}</p>
+                                <p class="text-sm text-gray-500">
+                                    Du {{ reservation.checkinDate|date('d/m/Y') }} au {{ reservation.checkoutDate|date('d/m/Y') }}
+                                    · {{ reservation.guestsCount }} voyageur(s)
+                                </p>
+                                <p class="text-sm text-gray-500">
+                                    {{ reservation.guest.email }} · {{ reservation.totalPrice }} {{ reservation.currency }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="mt-4 flex flex-wrap items-start gap-3">
+                            <form method="post" action="{{ path('app_host_request_accept', { id: reservation.id }) }}">
+                                <input type="hidden" name="_token" value="{{ csrf_token('moderate_' ~ reservation.id) }}">
+                                <button class="px-4 py-2 rounded-lg bg-gray-900 text-white text-sm font-medium">Accepter</button>
+                            </form>
+                            <form method="post" action="{{ path('app_host_request_refuse', { id: reservation.id }) }}" class="flex gap-2">
+                                <input type="hidden" name="_token" value="{{ csrf_token('moderate_' ~ reservation.id) }}">
+                                <input type="text" name="reason" placeholder="Motif du refus" required
+                                       class="px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                                <button class="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium">Refuser</button>
+                            </form>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <p class="text-gray-500">Aucune demande en attente.</p>
+        {% endif %}
+    </main>
+{% endblock %}

--- a/templates/front/property/booking.html.twig
+++ b/templates/front/property/booking.html.twig
@@ -18,11 +18,14 @@
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div class="lg:col-span-2">
                 <h1 class="text-2xl font-bold text-gray-900 mb-6">Finaliser votre réservation</h1>
-                <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm">
+                <div class="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm"
+                     data-controller="datepicker"
+                     data-datepicker-unavailable-checkin-value="{{ unavailableForCheckin|json_encode }}"
+                     data-datepicker-unavailable-checkout-value="{{ unavailableForCheckout|json_encode }}">
                     {{ form_start(form, { attr: { class: 'space-y-5' } }) }}
                         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            {{ form_row(form.checkinDate, { label: 'Arrivée', attr: { class: 'w-full border border-gray-300 rounded-xl px-4 py-3 text-sm' } }) }}
-                            {{ form_row(form.checkoutDate, { label: 'Départ', attr: { class: 'w-full border border-gray-300 rounded-xl px-4 py-3 text-sm' } }) }}
+                            {{ form_row(form.checkinDate, { label: 'Arrivée', attr: { class: 'w-full border border-gray-300 rounded-xl px-4 py-3 text-sm', 'data-datepicker-checkin': '' } }) }}
+                            {{ form_row(form.checkoutDate, { label: 'Départ', attr: { class: 'w-full border border-gray-300 rounded-xl px-4 py-3 text-sm', 'data-datepicker-checkout': '' } }) }}
                         </div>
                         {{ form_row(form.guestsCount, { label: 'Voyageurs', attr: { class: 'w-full border border-gray-300 rounded-xl px-4 py-3 text-sm', min: 1, max: property.maxGuests } }) }}
                         <button type="submit" class="w-full bg-brand hover:bg-brandHover text-white font-semibold py-3 rounded-xl">Confirmer la réservation</button>

--- a/templates/front/property/show.html.twig
+++ b/templates/front/property/show.html.twig
@@ -88,6 +88,42 @@
                     </section>
                 {% endif %}
 
+                <section class="pb-8 border-b border-gray-200">
+                    <h2 class="text-xl font-semibold text-gray-900 mb-6">Disponibilités</h2>
+                    {% set calMonth = 'now'|date_modify('first day of this month') %}
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                        {% for m in 0..1 %}
+                            {% set monthStart = calMonth|date_modify('+' ~ m ~ ' months') %}
+                            {% set daysInMonth = monthStart|date_modify('last day of this month')|date('j') %}
+                            {% set firstWeekday = monthStart|date('N') %}
+                            <div>
+                                {% set monthNames = ['Janvier','Février','Mars','Avril','Mai','Juin','Juillet','Août','Septembre','Octobre','Novembre','Décembre'] %}
+                        <p class="text-sm font-semibold text-gray-700 mb-2">{{ monthNames[monthStart|date('n') - 1] }} {{ monthStart|date('Y') }}</p>
+                                <div class="grid grid-cols-7 gap-1 text-center text-xs text-gray-400 mb-1">
+                                    {% for d in ['L','M','M','J','V','S','D'] %}<div>{{ d }}</div>{% endfor %}
+                                </div>
+                                <div class="grid grid-cols-7 gap-1 text-center text-xs">
+                                    {% if firstWeekday > 1 %}{% for blank in 1..(firstWeekday - 1) %}<div></div>{% endfor %}{% endif %}
+                                    {% for day in 1..daysInMonth %}
+                                        {% set dayStr = monthStart|date_modify('+' ~ (day - 1) ~ ' days')|date('Y-m-d') %}
+                                        {% set isPast = dayStr < 'now'|date('Y-m-d') %}
+                                        {% set isUnavailable = unavailableDates[dayStr] is defined %}
+                                        <div class="py-1.5 rounded
+                                            {% if isPast %} text-gray-300
+                                            {% elseif isUnavailable %} bg-gray-100 text-gray-400 line-through
+                                            {% else %} text-gray-800
+                                            {% endif %}">{{ day }}</div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                    <div class="flex gap-4 mt-4 text-xs text-gray-500">
+                        <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-gray-100 inline-block"></span> Indisponible</span>
+                        <span class="flex items-center gap-1"><span class="w-3 h-3 rounded bg-white border border-gray-300 inline-block"></span> Disponible</span>
+                    </div>
+                </section>
+
                 <section>
                     <h2 class="text-xl font-semibold text-gray-900 mb-6">
                         Avis ({{ totalReviews|default(property.reviews|length) }})

--- a/templates/front/reservation/show.html.twig
+++ b/templates/front/reservation/show.html.twig
@@ -61,6 +61,21 @@
                 <div class="border border-gray-200 rounded-xl p-6 sticky top-28">
                     <h2 class="text-lg font-semibold mb-4">Récapitulatif</h2>
                     <p class="text-xl font-bold">{{ reservation.totalPrice|number_format(2, ',', ' ') }} {{ reservation.currency|default('EUR') }}</p>
+
+                    {% if reservation.status in ['pending', 'confirmed'] %}
+                        <form method="post" action="{{ path('app_reservation_cancel', { id: reservation.id }) }}" class="mt-6 space-y-2">
+                            <input type="hidden" name="_token" value="{{ csrf_token('cancel_reservation_' ~ reservation.id) }}">
+                            <input type="text" name="reason" placeholder="Motif d'annulation" required
+                                   class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                            <button class="w-full px-4 py-2 rounded-lg border border-red-300 text-red-700 text-sm font-medium hover:bg-red-50">
+                                Annuler la réservation
+                            </button>
+                        </form>
+                    {% endif %}
+
+                    {% if reservation.cancellationReason %}
+                        <p class="mt-4 text-sm text-gray-500">Motif : {{ reservation.cancellationReason }}</p>
+                    {% endif %}
                 </div>
             </aside>
         </div>

--- a/templates/layout/app.html.twig
+++ b/templates/layout/app.html.twig
@@ -9,5 +9,16 @@
 
     {% include 'layout/partials/app/footer.html.twig' %}
 
+    <script>
+        document.querySelectorAll('img').forEach(img => {
+            img.addEventListener('error', () => {
+                if (!img.dataset.fallback) {
+                    img.dataset.fallback = '1';
+                    img.src = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='800' height='600'%3E%3Crect width='800' height='600' fill='%23f3f4f6'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='48' fill='%23d1d5db'%3E%F0%9F%8F%A0%3C/text%3E%3C/svg%3E";
+                }
+            });
+        });
+    </script>
+
     </body>
 {% endblock %}

--- a/templates/layout/partials/app/header_profile_menu.html.twig
+++ b/templates/layout/partials/app/header_profile_menu.html.twig
@@ -25,6 +25,14 @@
                 <i class="fa-solid fa-house w-4 text-center text-gray-400"></i>
                 Mes propriétés
             </a>
+            <a href="{{ path('app_host_requests') }}" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition">
+                <i class="fa-solid fa-bell-concierge w-4 text-center text-gray-400"></i>
+                Demandes reçues
+            </a>
+            <a href="{{ path('app_host_properties') }}" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition">
+                <i class="fa-solid fa-calendar-days w-4 text-center text-gray-400"></i>
+                Calendrier & disponibilités
+            </a>
             <a href="{{ path('app_messages_index') }}" class="flex items-center gap-3 px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition">
                 <i class="fa-solid fa-envelope w-4 text-center text-gray-400"></i>
                 Mes messages

--- a/tests/Service/AvailabilityServiceTest.php
+++ b/tests/Service/AvailabilityServiceTest.php
@@ -65,10 +65,10 @@ final class AvailabilityServiceTest extends TestCase
 
     private function service(bool $overlap, bool $blocked): AvailabilityService
     {
-        $reservations = $this->createMock(ReservationRepository::class);
+        $reservations = $this->createStub(ReservationRepository::class);
         $reservations->method('hasConfirmedOverlap')->willReturn($overlap);
 
-        $availabilities = $this->createMock(PropertyAvailabilityRepository::class);
+        $availabilities = $this->createStub(PropertyAvailabilityRepository::class);
         $availabilities->method('hasBlockedDay')->willReturn($blocked);
 
         return new AvailabilityService($reservations, $availabilities);

--- a/tests/Service/AvailabilityServiceTest.php
+++ b/tests/Service/AvailabilityServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Service;
+
+use App\Entity\Property;
+use App\Repository\PropertyAvailabilityRepository;
+use App\Repository\ReservationRepository;
+use App\Service\AvailabilityService;
+use PHPUnit\Framework\TestCase;
+
+final class AvailabilityServiceTest extends TestCase
+{
+    private \DateTimeImmutable $checkin;
+    private \DateTimeImmutable $checkout;
+
+    protected function setUp(): void
+    {
+        $this->checkin = new \DateTimeImmutable('2026-09-10');
+        $this->checkout = new \DateTimeImmutable('2026-09-14');
+    }
+
+    public function testAvailableWhenPublishedFreeAndWithinCapacity(): void
+    {
+        $service = $this->service(overlap: false, blocked: false);
+
+        self::assertTrue($service->isAvailable($this->property(), $this->checkin, $this->checkout, 2));
+    }
+
+    public function testUnavailableWhenNotPublished(): void
+    {
+        $service = $this->service(overlap: false, blocked: false);
+
+        self::assertFalse($service->isAvailable($this->property('draft'), $this->checkin, $this->checkout, 2));
+    }
+
+    public function testUnavailableWhenCapacityExceeded(): void
+    {
+        $service = $this->service(overlap: false, blocked: false);
+
+        self::assertFalse($service->isAvailable($this->property(), $this->checkin, $this->checkout, 99));
+    }
+
+    public function testUnavailableWhenConfirmedOverlap(): void
+    {
+        $service = $this->service(overlap: true, blocked: false);
+
+        self::assertFalse($service->isAvailable($this->property(), $this->checkin, $this->checkout, 2));
+    }
+
+    public function testUnavailableWhenHostBlockedDay(): void
+    {
+        $service = $this->service(overlap: false, blocked: true);
+
+        self::assertFalse($service->isAvailable($this->property(), $this->checkin, $this->checkout, 2));
+    }
+
+    public function testUnavailableWhenCheckinNotBeforeCheckout(): void
+    {
+        $service = $this->service(overlap: false, blocked: false);
+
+        self::assertFalse($service->isAvailable($this->property(), $this->checkout, $this->checkin, 2));
+    }
+
+    private function service(bool $overlap, bool $blocked): AvailabilityService
+    {
+        $reservations = $this->createMock(ReservationRepository::class);
+        $reservations->method('hasConfirmedOverlap')->willReturn($overlap);
+
+        $availabilities = $this->createMock(PropertyAvailabilityRepository::class);
+        $availabilities->method('hasBlockedDay')->willReturn($blocked);
+
+        return new AvailabilityService($reservations, $availabilities);
+    }
+
+    private function property(string $status = 'published'): Property
+    {
+        return (new Property())
+            ->setStatus($status)
+            ->setMaxGuests(4);
+    }
+}


### PR DESCRIPTION
## David Meguira

Voilà ce que j'ai fait pour ce TP, tout tourne en local avec Docker.

**Ce qui est implémenté :**

- Algorithme de dispo : 2 requêtes SQL pour valider une plage, contrainte EXCLUDE USING gist côté Postgres pour empêcher le double booking au niveau de la base
- Tunnel de réservation complet : instant booking (confirmed direct) + sur demande (pending → modération hôte)
- Interface hôte : calendrier mensuel avec navigation, blocage de périodes, gestion des demandes reçues
- Annulation avec motif, notifs aux deux parties
- Recherche par destination, dates et capacité
- Emails async via Symfony Messenger (worker doctrine transport)
- Export iCal sécurisé par token + commande d'import `app:ical:sync`
- Datepicker sur tous les formulaires de dates, avec les dates indisponibles grisées
- Calendrier de dispo visible côté voyageur sur la page logement

**Bonus :** import iCal (F), calendrier client, datepicker flatpickr partout

`conception.txt` à la racine. 6 tests PHPUnit sur `AvailabilityService`.